### PR TITLE
Support for TIFF's and JPEG's

### DIFF
--- a/hocr-pdf
+++ b/hocr-pdf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python	
+#!/usr/bin/env python
 #
 # Copyright 2013 Google Inc. All Rights Reserved.
 #

--- a/hocr-pdf
+++ b/hocr-pdf
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 #
 # Copyright 2013 Google Inc. All Rights Reserved.
 #
@@ -26,6 +26,7 @@ import os.path
 import re
 import sys
 import zlib
+import imghdr
 
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
@@ -49,14 +50,14 @@ class StdoutWrapper:
 
 def export_pdf(playground, default_dpi, savefile=False):
     """Create a searchable PDF from a pile of HOCR + JPEG"""
-    images = sorted(glob.glob(os.path.join(playground, '*.jpg')))
+    images = sorted(glob.glob(playground))
     if len(images) == 0:
-        print("WARNING: No JPG images found in the folder", playground,
+        print("WARNING: File not found ", playground,
               "\nScript cannot proceed without them and will terminate now.\n")
         sys.exit(0)
     load_invisible_font()
     pdf = Canvas(savefile if savefile else StdoutWrapper(), pageCompression=1)
-    pdf.setCreator('hocr-tools')
+    pdf.setCreator('Raven Cloud')
     pdf.setTitle(os.path.basename(playground))
     dpi = default_dpi
     for image in images:
@@ -132,21 +133,18 @@ AAEAAAAPAIAAAwBwR0RFRgARAJ0AADV0AAAAFkdQT1MDgC91AAA1jAAABABHU1VC3ELqOwAAOYwAAABc
 
     pdfmetrics.registerFont(TTFont('karla', ttf))
 
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Create a searchable PDF from a pile of hOCR and JPEG")
     parser.add_argument(
-        "imgdir",
-        help=("directory with the hOCR and JPEG files (corresponding "
-              "JPEG and hOCR files have to have the same name with "
-              "their respective file ending)")
+        "img",
+        help=("The image to be converted JPG, JPEG or TIFF")
     )
     parser.add_argument(
         "--savefile",
         help="Save to this file instead of outputting to stdout"
     )
     args = parser.parse_args()
-    if not os.path.isdir(args.imgdir):
-        sys.exit("ERROR: Given path '" + args.imgdir + "' is not a directory")
-    export_pdf(args.imgdir, 300, args.savefile)
+    if not args.img.lower().endswith(('.tiff', '.jpg', '.jpeg')):
+        sys.exit("ERROR: Invalid image type")
+    export_pdf(args.img, 300, args.savefile)

--- a/hocr-pdf
+++ b/hocr-pdf
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python	
 #
 # Copyright 2013 Google Inc. All Rights Reserved.
 #


### PR DESCRIPTION
Modified to ensure .tiff files can be sent as parameter and .jpegs, before the script only searches for a files in the selected directory but now you need to specify the file image to use.