### PR TITLE
Fixed the way right to left language (Hebrew) text is inserted to pdf

### DIFF
--- a/hocr-pdf
+++ b/hocr-pdf
@@ -28,11 +28,10 @@ import sys
 import zlib
 import imghdr
 
-import bidi.algorithm
-
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.pdfgen.canvas import Canvas
+from bidi.algorithm import get_display
 
 from lxml import etree, html
 from PIL import Image
@@ -143,7 +142,7 @@ def add_text_layer(pdf, image, height, dpi):
             text.setTextOrigin(box[0] * 72 / dpi, height - b * 72 / dpi)
             box_width = (box[2] - box[0]) * 72 / dpi
             text.setHorizScale(100.0 * box_width / font_width)
-            rawtext = bidi.algorithm.get_display(rawtext)
+            rawtext = get_display(rawtext)
             text.textLine(rawtext)
             pdf.drawText(text)
 

--- a/hocr-pdf
+++ b/hocr-pdf
@@ -28,6 +28,8 @@ import sys
 import zlib
 import imghdr
 
+import bidi.algorithm
+
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 from reportlab.pdfgen.canvas import Canvas
@@ -141,6 +143,7 @@ def add_text_layer(pdf, image, height, dpi):
             text.setTextOrigin(box[0] * 72 / dpi, height - b * 72 / dpi)
             box_width = (box[2] - box[0]) * 72 / dpi
             text.setHorizScale(100.0 * box_width / font_width)
+            rawtext = bidi.algorithm.get_display(rawtext)
             text.textLine(rawtext)
             pdf.drawText(text)
 


### PR DESCRIPTION
## Issue Description:

The pdf file generated using `hocr-pdf` has Hebrew text printed in the opposite direction.

Steps I followed:
1. I used Google cloud vision to get the OCR 
2. Used gcv2hocr to generate hocr.
3. Used `hocr-pdf --savefile output.pdf actual-file.jpg` to generate pdf file.

The pdf file has Hebrew text inserted in it but in the reverse order.

### Actual image:

<img width="262" alt="Screen Shot 2021-02-01 at 6 48 35 PM" src="https://user-images.githubusercontent.com/3844756/106536559-53f41100-64be-11eb-93b2-a3576a917a00.png">

### This is how hocr file looks:

<img width="623" alt="Screen Shot 2021-02-01 at 7 01 04 PM" src="https://user-images.githubusercontent.com/3844756/106537430-ed6ff280-64bf-11eb-8954-fed6da879428.png">


### Text in pdf file: (I have set text visibility mode to 0 so that the inserted text is visible)

<img width="265" alt="Screen Shot 2021-02-01 at 6 48 56 PM" src="https://user-images.githubusercontent.com/3844756/106536944-fad8ad00-64be-11eb-9ff4-c95ad4a4accf.png">

## Solution:
Use [python package](https://pypi.org/project/python-bidi/) for bidi algorithm ( [Bi-Directional Algorithm](https://www.w3.org/International/articles/inline-bidi-markup/uba-basics) ) to transform text before drawing it into the pdf file.

Solution is based on the suggestion: https://github.com/ocropus/hocr-tools/issues/163

## Tests:
Tested both Hebrew text image and English text image and they give expected results.

## For Issue: 
https://github.com/StarfishCo/api.raven.com/issues/3740